### PR TITLE
Add multi-identity matrix support

### DIFF
--- a/cmd/bot/handlers.go
+++ b/cmd/bot/handlers.go
@@ -14,35 +14,37 @@ import (
 
 // SetupMatrixHandlers는 Matrix 이벤트 핸들러를 설정합니다.
 func SetupMatrixHandlers(ctx context.Context, appSetup *setup.AppSetup, roomSendlocks RoomSendLocks) {
-	// Matrix 어뎁터 생성
-	matrixClient := matrix.NewMautrixClientAdapter(appSetup.Client)
+	for _, client := range appSetup.MatrixClients {
+		// Matrix 어뎁터 생성
+		matrixClient := matrix.NewMautrixClientAdapter(client)
 
-	// ChatwootAPIs를 func 형태로 변환
-	getChatwootAPI := func(accountID chatwootapi.AccountID) *chatwootapi.Client {
-		return appSetup.ChatwootAPIs[accountID]
+		// ChatwootAPIs를 func 형태로 변환
+		getChatwootAPI := func(accountID chatwootapi.AccountID) *chatwootapi.Client {
+			return appSetup.ChatwootAPIs[accountID]
+		}
+
+		// ConversationManager 생성
+		convManager := conversation.NewManager(matrixClient, appSetup.DB, getChatwootAPI, appSetup.DefaultAccountID, 100)
+
+		// MessageHelper 생성
+		messageHelper := matrix.NewMessageHelper(client, getChatwootAPI, false, appSetup.DB)
+
+		// Matrix 핸들러 생성
+		matrixHandler := matrix.NewMatrixHandler(
+			matrixClient,
+			appSetup.ChatwootAPIs,
+			appSetup.DefaultAccountID,
+			appSetup.DB,
+			messageHelper,
+			convManager,
+		)
+
+		// Syncer 가져오기
+		syncer := client.Syncer.(*mautrix.DefaultSyncer)
+
+		// 이벤트 핸들러 등록
+		registerEventHandlers(ctx, syncer, matrixHandler, client)
 	}
-
-	// ConversationManager 생성
-	convManager := conversation.NewManager(matrixClient, appSetup.DB, getChatwootAPI, appSetup.DefaultAccountID, 100)
-
-	// MessageHelper 생성
-	messageHelper := matrix.NewMessageHelper(appSetup.Client, getChatwootAPI, false, appSetup.DB)
-
-	// Matrix 핸들러 생성
-	matrixHandler := matrix.NewMatrixHandler(
-		matrixClient,
-		appSetup.ChatwootAPIs,
-		appSetup.DefaultAccountID,
-		appSetup.DB,
-		messageHelper,
-		convManager,
-	)
-
-	// Syncer 가져오기
-	syncer := appSetup.Client.Syncer.(*mautrix.DefaultSyncer)
-
-	// 이벤트 핸들러 등록
-	registerEventHandlers(ctx, syncer, matrixHandler, appSetup.Client)
 }
 
 // registerEventHandlers는 Matrix 이벤트 핸들러를 등록합니다.

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -44,9 +44,6 @@ func main() {
 	// 방 동기화 락 초기화
 	roomSendlocks := NewRoomSendLocks()
 
-	// 종료 핸들러 설정
-	setup.SetupShutdownHandler(ctx, appSetup.Client, appSetup.CryptoHelper, appSetup.DB, log)
-
 	// Matrix 이벤트 핸들러 등록
 	SetupMatrixHandlers(ctx, appSetup, roomSendlocks)
 

--- a/cmd/bot/server.go
+++ b/cmd/bot/server.go
@@ -11,15 +11,23 @@ import (
 	"github.com/Nocha12/chatwoot-mirroring-bot/pkg/chatwootapi"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
+	"maunium.net/go/mautrix"
 )
 
 // StartWebhookServer는 웹훅 서버를 시작합니다.
 func StartWebhookServer(ctx context.Context, appSetup *setup.AppSetup, roomSendlocks RoomSendLocks) {
 	log := zerolog.Ctx(ctx)
-	
+
 	// 웹훅 리스너 설정
 	messageHandler := chatwoot.NewMessageHandler(
-		appSetup.Client,
+		func(accID chatwootapi.AccountID, inboxID chatwootapi.InboxID) *mautrix.Client {
+			client, err := appSetup.MatrixClientForChatwootAccount(ctx, accID, inboxID)
+			if err != nil {
+				log.Error().Err(err).Msg("matrix client lookup failed")
+				return appSetup.Client
+			}
+			return client
+		},
 		appSetup.DB,
 		appSetup.ChatwootAPIs,
 		func(accountID chatwootapi.AccountID) *chatwootapi.Client {
@@ -44,7 +52,7 @@ func StartWebhookServer(ctx context.Context, appSetup *setup.AppSetup, roomSendl
 	http.Handle("/", handler)
 	http.Handle("/webhook", handler)
 	log.Info().Int("listen_port", appSetup.Config.HTTPListenPort).Msg("웹훅 리스너 시작 중")
-	
+
 	go func() {
 		err := http.ListenAndServe(fmt.Sprintf(":%d", appSetup.Config.HTTPListenPort), nil)
 		if err != nil {

--- a/internal/chatwoot/attachment.go
+++ b/internal/chatwoot/attachment.go
@@ -19,7 +19,7 @@ import (
 )
 
 // handleAttachment는 Chatwoot 첨부파일을 처리하여 Matrix에 전송하는 함수입니다.
-func (h *MessageHandler) handleAttachment(ctx context.Context, roomID id.RoomID, chatwootMessageID chatwootapi.MessageID, chatwootAttachment chatwootapi.Attachment) (*mautrix.RespSendEvent, error) {
+func (h *MessageHandler) handleAttachment(ctx context.Context, roomID id.RoomID, accountID chatwootapi.AccountID, inboxID chatwootapi.InboxID, chatwootMessageID chatwootapi.MessageID, chatwootAttachment chatwootapi.Attachment) (*mautrix.RespSendEvent, error) {
 	log := zerolog.Ctx(ctx).With().
 		Str("component", "handle_attachment").
 		Int("attachment_id", int(chatwootAttachment.ID)).
@@ -30,6 +30,12 @@ func (h *MessageHandler) handleAttachment(ctx context.Context, roomID id.RoomID,
 
 	// Chatwoot API 클라이언트 가져오기
 	api := h.GetAPI(chatwootapi.AccountID(chatwootAttachment.AccountID))
+
+	matrixClient := h.GetMatrixClient(accountID, inboxID)
+	if matrixClient == nil {
+		log.Error().Msg("Matrix 클라이언트를 찾을 수 없습니다")
+		return nil, fmt.Errorf("matrix client not found")
+	}
 
 	// 첨부파일 다운로드
 	log.Debug().Str("data_url", chatwootAttachment.DataURL).Msg("첨부파일 다운로드 시작")
@@ -73,7 +79,7 @@ func (h *MessageHandler) handleAttachment(ctx context.Context, roomID id.RoomID,
 	}
 
 	// 파일 업로드
-	uploadResp, err := h.Client.UploadBytes(ctx, attachmentData, fileType)
+	uploadResp, err := matrixClient.UploadBytes(ctx, attachmentData, fileType)
 	if err != nil {
 		log.Error().Err(err).Msg("Matrix 미디어 업로드 실패")
 		return nil, err
@@ -103,7 +109,7 @@ func (h *MessageHandler) handleAttachment(ctx context.Context, roomID id.RoomID,
 	}
 
 	// 메시지 전송
-	sentEvent, err := h.SendMessage(ctx, roomID, content)
+	sentEvent, err := h.SendMessage(ctx, matrixClient, roomID, content)
 	if err != nil {
 		log.Error().Err(err).Msg("첨부파일 메시지 전송 실패")
 		return nil, err

--- a/internal/chatwoot/handler.go
+++ b/internal/chatwoot/handler.go
@@ -13,26 +13,26 @@ import (
 // MessageHandler는 Chatwoot 메시지 이벤트를 처리하는 구조체입니다.
 type MessageHandler struct {
 	// 의존성 주입을 위한 필드들
-	Client        *mautrix.Client
-	StateStore    *database.Database
-	ChatwootAPIs  map[chatwootapi.AccountID]*chatwootapi.Client
-	GetAPI        func(accountID chatwootapi.AccountID) *chatwootapi.Client
-	RoomSendlocks map[id.RoomID]*sync.Mutex
+	GetMatrixClient func(accountID chatwootapi.AccountID, inboxID chatwootapi.InboxID) *mautrix.Client
+	StateStore      *database.Database
+	ChatwootAPIs    map[chatwootapi.AccountID]*chatwootapi.Client
+	GetAPI          func(accountID chatwootapi.AccountID) *chatwootapi.Client
+	RoomSendlocks   map[id.RoomID]*sync.Mutex
 }
 
 // NewMessageHandler는 새로운 MessageHandler 인스턴스를 생성합니다.
 func NewMessageHandler(
-	client *mautrix.Client,
+	getMatrixClient func(accountID chatwootapi.AccountID, inboxID chatwootapi.InboxID) *mautrix.Client,
 	stateStore *database.Database,
 	chatwootAPIs map[chatwootapi.AccountID]*chatwootapi.Client,
 	getAPIFunc func(accountID chatwootapi.AccountID) *chatwootapi.Client,
 	roomSendlocks map[id.RoomID]*sync.Mutex,
 ) *MessageHandler {
 	return &MessageHandler{
-		Client:        client,
-		StateStore:    stateStore,
-		ChatwootAPIs:  chatwootAPIs,
-		GetAPI:        getAPIFunc,
-		RoomSendlocks: roomSendlocks,
+		GetMatrixClient: getMatrixClient,
+		StateStore:      stateStore,
+		ChatwootAPIs:    chatwootAPIs,
+		GetAPI:          getAPIFunc,
+		RoomSendlocks:   roomSendlocks,
 	}
 }

--- a/internal/chatwoot/message.go
+++ b/internal/chatwoot/message.go
@@ -16,7 +16,7 @@ import (
 )
 
 // SendMessage는 Matrix 방에 메시지를 전송하는 함수입니다.
-func (h *MessageHandler) SendMessage(ctx context.Context, roomID id.RoomID, content *event.MessageEventContent, extraContent ...map[string]any) (resp *mautrix.RespSendEvent, err error) {
+func (h *MessageHandler) SendMessage(ctx context.Context, client *mautrix.Client, roomID id.RoomID, content *event.MessageEventContent, extraContent ...map[string]any) (resp *mautrix.RespSendEvent, err error) {
 	lock, ok := h.RoomSendlocks[roomID]
 	if !ok {
 		lock = &sync.Mutex{}
@@ -47,7 +47,7 @@ func (h *MessageHandler) SendMessage(ctx context.Context, roomID id.RoomID, cont
 		}
 	}
 
-	return h.Client.SendMessageEvent(ctx, roomID, event.EventMessage, mergedContent)
+	return client.SendMessageEvent(ctx, roomID, event.EventMessage, mergedContent)
 }
 
 // HandleMessageCreated는 Chatwoot에서 메시지가 생성되었을 때 실행되는 핸들러입니다.
@@ -97,8 +97,13 @@ func (h *MessageHandler) HandleMessageCreated(ctx context.Context, mc chatwootap
 			return nil
 		}
 
+		matrixClient := h.GetMatrixClient(chatwootapi.AccountID(mc.Conversation.AccountID), chatwootapi.InboxID(mc.Conversation.InboxID))
+		if matrixClient == nil {
+			log.Error().Msg("Matrix 클라이언트를 찾을 수 없습니다")
+			return fmt.Errorf("matrix client not found")
+		}
 		// Matrix에서 메시지 삭제 (redact)
-		_, err = h.Client.RedactEvent(ctx, roomID, matrixEventID)
+		_, err = matrixClient.RedactEvent(ctx, roomID, matrixEventID)
 		if err != nil {
 			log.Error().Err(err).Msg("Matrix 메시지 삭제 실패")
 			return err
@@ -124,8 +129,14 @@ func (h *MessageHandler) HandleMessageCreated(ctx context.Context, mc chatwootap
 		return err
 	}
 
+	matrixClient := h.GetMatrixClient(accountID, chatwootapi.InboxID(mc.Conversation.InboxID))
+	if matrixClient == nil {
+		log.Error().Msg("Matrix 클라이언트를 찾을 수 없습니다")
+		return fmt.Errorf("matrix client not found")
+	}
+
 	// 방 존재 여부 검증
-	exists, err := h.validateRoomExists(ctx, roomID)
+	exists, err := h.validateRoomExists(ctx, matrixClient, roomID)
 	if err != nil {
 		log.Error().Err(err).Msg("방 존재 여부 확인 실패")
 		return err
@@ -158,7 +169,7 @@ func (h *MessageHandler) HandleMessageCreated(ctx context.Context, mc chatwootap
 
 		// 첫 번째 첨부파일만 처리 (여러 개 있을 경우 나머지는 추가 메시지로 전송 가능)
 		attachment := mc.ContentAttributes.Attachments[0]
-		sentEvent, err = h.handleAttachment(ctx, roomID, mc.ID, attachment)
+		sentEvent, err = h.handleAttachment(ctx, roomID, chatwootapi.AccountID(mc.Conversation.AccountID), chatwootapi.InboxID(mc.Conversation.InboxID), mc.ID, attachment)
 		if err != nil {
 			log.Error().Err(err).Msg("첨부파일 처리 실패")
 			// 첨부파일 처리 실패시에도 텍스트 메시지는 보낼 수 있도록 진행
@@ -177,7 +188,7 @@ func (h *MessageHandler) HandleMessageCreated(ctx context.Context, mc chatwootap
 
 	// 텍스트 메시지 전송 (첨부파일이 없거나, 첨부파일과 텍스트가 모두 있는 경우)
 	if sentEvent == nil || mc.Content != "" {
-		sentEvent, err = h.SendMessage(ctx, roomID, msgContent)
+		sentEvent, err = h.SendMessage(ctx, matrixClient, roomID, msgContent)
 		if err != nil {
 			log.Error().Err(err).Msg("Matrix 메시지 전송 실패")
 			return err

--- a/internal/chatwoot/validation.go
+++ b/internal/chatwoot/validation.go
@@ -10,13 +10,13 @@ import (
 )
 
 // validateRoomExists는 Matrix 방이 존재하는지 확인하는 함수입니다.
-func (h *MessageHandler) validateRoomExists(ctx context.Context, roomID id.RoomID) (bool, error) {
+func (h *MessageHandler) validateRoomExists(ctx context.Context, client *mautrix.Client, roomID id.RoomID) (bool, error) {
 	log := zerolog.Ctx(ctx)
 	log.Debug().Stringer("room_id", roomID).Msg("방 존재 여부 확인")
 
 	// 방의 암호화 상태 확인
 	var encState *event.EncryptionEventContent
-	err := h.Client.StateEvent(ctx, roomID, event.StateEncryption, "", &encState)
+	err := client.StateEvent(ctx, roomID, event.StateEncryption, "", &encState)
 	if err != nil {
 		// 404 오류면 방이 없거나 액세스할 수 없는 것
 		// 403 오류면 액세스할 수 없는 것 (초대되지 않음)
@@ -25,7 +25,7 @@ func (h *MessageHandler) validateRoomExists(ctx context.Context, roomID id.RoomI
 			log.Debug().Err(err).Str("error_code", httpErr.RespError.ErrCode).Msg("방이 존재하지 않거나 액세스할 수 없음")
 
 			// 방에 참여 시도
-			_, joinErr := h.Client.JoinRoomByID(ctx, roomID)
+			_, joinErr := client.JoinRoomByID(ctx, roomID)
 			if joinErr != nil {
 				log.Warn().Err(joinErr).Msg("방 참여 시도 실패")
 				return false, nil

--- a/internal/setup/account_mapping_helpers.go
+++ b/internal/setup/account_mapping_helpers.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/rs/zerolog"
+	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/id"
 
 	"github.com/Nocha12/chatwoot-mirroring-bot/pkg/chatwootapi"
@@ -205,4 +206,29 @@ func (app *AppSetup) GetAllActiveMappings(ctx context.Context) []*struct {
 
 	log.Debug().Int("mappings_count", len(result)).Msg("활성화된 계정 매핑 정보 조회 완료")
 	return result
+}
+
+// MatrixClientForChatwootAccount는 Chatwoot 계정/인박스에 매핑된 Matrix 클라이언트를 반환합니다.
+func (app *AppSetup) MatrixClientForChatwootAccount(
+	ctx context.Context,
+	accountID chatwootapi.AccountID,
+	inboxID chatwootapi.InboxID,
+) (*mautrix.Client, error) {
+	log := zerolog.Ctx(ctx).With().
+		Str("component", "matrix_client_for_chatwoot_account").
+		Int("chatwoot_account_id", int(accountID)).
+		Int("chatwoot_inbox_id", int(inboxID)).
+		Logger()
+
+	userID, err := app.MatrixUserIDForChatwootAccount(ctx, accountID, inboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	client, ok := app.MatrixClients[userID]
+	if !ok {
+		return nil, fmt.Errorf("matrix client for %s not found", userID)
+	}
+	log.Debug().Str("matrix_user_id", string(userID)).Msg("Matrix 클라이언트 조회 완료")
+	return client, nil
 }

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog"
 	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/crypto/cryptohelper"
+	"maunium.net/go/mautrix/id"
 )
 
 // AppSetup는 애플리케이션 실행에 필요한 공유 객체를 담고 있습니다.
@@ -20,6 +21,8 @@ type AppSetup struct {
 	DB               *database.Database
 	Client           *mautrix.Client
 	CryptoHelper     *cryptohelper.CryptoHelper
+	MatrixClients    map[id.UserID]*mautrix.Client
+	CryptoHelpers    map[id.UserID]*cryptohelper.CryptoHelper
 	ChatwootAPIs     map[chatwootapi.AccountID]*chatwootapi.Client
 	DefaultAccountID chatwootapi.AccountID
 
@@ -74,33 +77,40 @@ func SetupApp(configPath string) (*AppSetup, error) {
 	}
 
 	// 5) Matrix 클라이언트 및 암호화 헬퍼 초기화
-	var homeserver, user, password string
+	matrixClients := make(map[id.UserID]*mautrix.Client)
+	cryptoHelpers := make(map[id.UserID]*cryptohelper.CryptoHelper)
+	var client *mautrix.Client
+	var cryptoHelper *cryptohelper.CryptoHelper
 
-	// 항상 데이터베이스 설정을 우선 사용
-	if runtimeCfg != nil && runtimeCfg.Password != "" {
-		// 데이터베이스에서 로드한 계정 정보 사용
-		homeserver = runtimeCfg.Homeserver
-		user = runtimeCfg.Username.String()
-		password = runtimeCfg.Password
-		log.Info().Msg("데이터베이스에서 로드한 Matrix 계정 정보를 사용합니다")
-	} else if cfg != nil {
-		// 설정 파일의 계정 정보 사용 (backup)
-		homeserver = cfg.Homeserver
-		user = cfg.Username.String()
-		pw, err := cfg.GetPassword(&log)
-		if err != nil {
-			// 비밀번호 파일이 없어도 계속 진행 (비어있는 비밀번호 사용)
-			log.Warn().Err(err).Msg("비밀번호 파일에서 Matrix 비밀번호를 가져올 수 없습니다")
-			pw = ""
-		}
-		password = pw
-		log.Info().Msg("설정 파일에서 로드한 Matrix 계정 정보를 사용합니다")
-	} else {
-		return nil, fmt.Errorf("Matrix 계정 정보를 데이터베이스나 설정 파일에서 찾을 수 없습니다")
-	}
-	client, cryptoHelper, err := SetupMatrixClient(homeserver, user, password, db, log)
+	identityConfigs, err := queries.GetMatrixIdentities(ctx, db)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("matrix 계정 로드 실패: %w", err)
+	}
+
+	for _, ident := range identityConfigs {
+		if !ident.IsEnabled {
+			continue
+		}
+		pw, err := queries.DecryptMatrixPassword(ident, masterKey, &log)
+		if err != nil {
+			log.Error().Err(err).Int("identity_id", ident.ID).Msg("비밀번호 복호화 실패")
+			continue
+		}
+
+		c, h, err := SetupMatrixClient(ident.HomeserverURL, ident.UserID.String(), pw, db, log)
+		if err != nil {
+			return nil, err
+		}
+		matrixClients[ident.UserID] = c
+		cryptoHelpers[ident.UserID] = h
+		if client == nil {
+			client = c
+			cryptoHelper = h
+		}
+	}
+
+	if client == nil {
+		return nil, fmt.Errorf("활성화된 Matrix 계정이 없습니다")
 	}
 
 	// 6) Chatwoot API 클라이언트 맵 생성
@@ -154,8 +164,11 @@ func SetupApp(configPath string) (*AppSetup, error) {
 	}
 
 	// 10) 콜백 및 종료 핸들러 등록
-	SetupCallbacks(cryptoHelper, log, db, apis, defaultAccID)
-	SetupShutdownHandler(ctx, client, cryptoHelper, db, log)
+	for uid, helper := range cryptoHelpers {
+		SetupCallbacks(helper, log, db, apis, defaultAccID)
+		c := matrixClients[uid]
+		SetupShutdownHandler(ctx, c, helper, db, log)
+	}
 
 	// 11) AppSetup 조립 및 반환
 	app := &AppSetup{
@@ -163,6 +176,8 @@ func SetupApp(configPath string) (*AppSetup, error) {
 		DB:               db,
 		Client:           client,
 		CryptoHelper:     cryptoHelper,
+		MatrixClients:    matrixClients,
+		CryptoHelpers:    cryptoHelpers,
 		ChatwootAPIs:     apis,
 		DefaultAccountID: defaultAccID,
 		AccountMappings:  accountMappings,


### PR DESCRIPTION
## Summary
- support multiple Matrix identities
- route Chatwoot events to the correct Matrix client
- iterate event handlers for all Matrix clients

## Testing
- `go list ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*