### PR TITLE
Replace any with explicit interface types

### DIFF
--- a/cmd/bot/main.go.bak
+++ b/cmd/bot/main.go.bak
@@ -295,6 +295,6 @@ func VerifyFromAuthorizedUser(ctx context.Context, sender id.UserID) bool {
 	return setup.VerifyFromAuthorizedUser(ctx, sender)
 }
 
-func DoRetry[T any](ctx context.Context, action string, fn func(context.Context) (T, error)) (T, error) {
+func DoRetry[T interface{}](ctx context.Context, action string, fn func(context.Context) (T, error)) (T, error) {
 	return util.DoRetry(ctx, action, fn)
 }

--- a/cmd/bot/utils.go
+++ b/cmd/bot/utils.go
@@ -18,7 +18,7 @@ func VerifyFromAuthorizedUser(ctx context.Context, sender id.UserID) bool {
 }
 
 // DoRetry는 지정된 작업을 재시도합니다.
-func DoRetry[T any](ctx context.Context, action string, fn func(context.Context) (T, error)) (T, error) {
+func DoRetry[T interface{}](ctx context.Context, action string, fn func(context.Context) (T, error)) (T, error) {
 	return util.DoRetry(ctx, action, fn)
 }
 
@@ -35,7 +35,7 @@ func SetupSignalHandler(ctx context.Context, appSetup *setup.AppSetup) {
 		syscall.SIGQUIT,
 		syscall.SIGTERM,
 	)
-	
+
 	go func() {
 		for range c { // 프로세스가 종료될 때
 			log.Info().Msg("정리 중...")

--- a/helper.go
+++ b/helper.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sethvargo/go-retry"
 )
 
-func DoRetry[T any](ctx context.Context, action string, fn func(context.Context) (T, error)) (T, error) {
+func DoRetry[T interface{}](ctx context.Context, action string, fn func(context.Context) (T, error)) (T, error) {
 	var result T
 	var err error
 	log := zerolog.Ctx(ctx)
@@ -28,7 +28,7 @@ func DoRetry[T any](ctx context.Context, action string, fn func(context.Context)
 	return result, err
 }
 
-func DoRetryArr[T any](ctx context.Context, action string, fn func(context.Context) ([]T, error)) ([]T, error) {
+func DoRetryArr[T interface{}](ctx context.Context, action string, fn func(context.Context) ([]T, error)) ([]T, error) {
 	var result []T
 	var err error
 	log := zerolog.Ctx(ctx)

--- a/internal/chatwoot/message.go
+++ b/internal/chatwoot/message.go
@@ -16,7 +16,7 @@ import (
 )
 
 // SendMessage는 Matrix 방에 메시지를 전송하는 함수입니다.
-func (h *MessageHandler) SendMessage(ctx context.Context, roomID id.RoomID, content *event.MessageEventContent, extraContent ...map[string]any) (resp *mautrix.RespSendEvent, err error) {
+func (h *MessageHandler) SendMessage(ctx context.Context, roomID id.RoomID, content *event.MessageEventContent, extraContent ...map[string]interface{}) (resp *mautrix.RespSendEvent, err error) {
 	lock, ok := h.RoomSendlocks[roomID]
 	if !ok {
 		lock = &sync.Mutex{}

--- a/internal/conversation/conversation.go
+++ b/internal/conversation/conversation.go
@@ -49,7 +49,7 @@ func (m *ManagerImpl) createChatwootConversation(ctx context.Context, roomID id.
 		// Twitter 사용자 이름에 대한 특별한 처리
 		contactName := ""
 		if strings.HasPrefix(contactMXID.Localpart(), "twitter_") {
-			memberEventContent := map[string]any{}
+			memberEventContent := map[string]interface{}{}
 			if err := m.Client.StateEvent(ctx, roomID, event.StateMember, contactMXID.String(), &memberEventContent); err == nil {
 				log.Trace().Any("member_event_content", memberEventContent).Msg("Got member event content")
 				if identifiers, ok := memberEventContent["com.beeper.bridge.identifiers"]; ok {
@@ -148,5 +148,3 @@ func (m *ManagerImpl) createChatwootConversation(ctx context.Context, roomID id.
 		Msg("Chatwoot 대화 생성 및 연결 완료")
 	return conversation.ID, nil
 }
-
-

--- a/internal/matrix/utils.go
+++ b/internal/matrix/utils.go
@@ -29,7 +29,7 @@ func GetOrCreateRoomLock(roomID id.RoomID) *sync.Mutex {
 }
 
 // SendMessage는 Matrix 방에 메시지를 전송합니다.
-func SendMessage(ctx context.Context, client MatrixClient, roomID id.RoomID, content *event.MessageEventContent, extraContent ...map[string]any) (*mautrix.RespSendEvent, error) {
+func SendMessage(ctx context.Context, client MatrixClient, roomID id.RoomID, content *event.MessageEventContent, extraContent ...map[string]interface{}) (*mautrix.RespSendEvent, error) {
 	log := zerolog.Ctx(ctx).With().Stringer("room_id", roomID).Logger()
 	ctx = log.WithContext(ctx)
 
@@ -74,7 +74,7 @@ func logError(ctx context.Context, err error, component string, msg string, fiel
 			}
 		}
 	}
-	
+
 	// logger.Logger()는 값을 반환하므로 Error() 포인터 메서드를 직접 호출할 수 없습니다.
 	// 대신 컨텍스트에서 로거를 가져와 사용합니다.
 	logObj := logger.Logger()

--- a/internal/util/retry.go
+++ b/internal/util/retry.go
@@ -9,7 +9,7 @@ import (
 )
 
 // DoRetry는 함수 실행을 재시도하는 범용 헬퍼 함수입니다.
-func DoRetry[T any](ctx context.Context, action string, fn func(context.Context) (T, error)) (T, error) {
+func DoRetry[T interface{}](ctx context.Context, action string, fn func(context.Context) (T, error)) (T, error) {
 	var result T
 	var err error
 	log := zerolog.Ctx(ctx)
@@ -29,7 +29,7 @@ func DoRetry[T any](ctx context.Context, action string, fn func(context.Context)
 }
 
 // DoRetryArr는 배열을 반환하는 함수에 대한 재시도 헬퍼 함수입니다.
-func DoRetryArr[T any](ctx context.Context, action string, fn func(context.Context) ([]T, error)) ([]T, error) {
+func DoRetryArr[T interface{}](ctx context.Context, action string, fn func(context.Context) ([]T, error)) ([]T, error) {
 	var result []T
 	var err error
 	log := zerolog.Ctx(ctx)


### PR DESCRIPTION
## Summary
- replace `any` with `interface{}` in DoRetry helpers
- update related wrappers and unused file
- switch map types from `map[string]any` to `map[string]interface{}`

## Testing
- `go vet ./...` *(fails: no route to host)*