### PR TITLE
Add build and lint steps before PR

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,3 +27,13 @@ repos:
       - id: zerolog-ban-global-log
       - id: zerolog-ban-msgf
       - id: zerolog-use-stringer
+  - repo: local
+    hooks:
+      - id: go-build
+        name: go build
+        entry: go build -o chatwoot ./cmd/bot
+        language: system
+      - id: golangci-lint
+        name: golangci-lint
+        entry: golangci-lint run ./...
+        language: system

--- a/README.md
+++ b/README.md
@@ -41,3 +41,17 @@ support the feature
 ## Configuration
 
 See `example-config.yaml` for details about each config option.
+
+## Development
+
+Pull requests should pass a build and lint check before submission. Run the following commands in your environment:
+
+```bash
+# compile the bot
+go build -o chatwoot ./cmd/bot
+
+# run golangci-lint
+golangci-lint run ./...
+```
+
+These checks are also included in the pre-commit hooks.


### PR DESCRIPTION
## Summary
- add documentation on running go build and golangci-lint
- wire build and lint commands into pre-commit hooks

## Testing
- `go build -o chatwoot ./cmd/bot` *(fails: no route to host)*
- `golangci-lint run ./...` *(fails: typecheck errors)*