### PR TITLE
Implement OCI streaming

### DIFF
--- a/cmd/bot/consumer.go
+++ b/cmd/bot/consumer.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"time"
+
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/chatwoot"
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/conversation"
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/matrix"
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/oci"
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/setup"
+	"github.com/Nocha12/chatwoot-mirroring-bot/pkg/chatwootapi"
+	"github.com/rs/zerolog"
+	"maunium.net/go/mautrix"
+)
+
+// StartConsumerLoop 는 스트림에서 메시지를 읽어 기존 처리 로직을 호출합니다.
+func StartConsumerLoop(ctx context.Context, appSetup *setup.AppSetup) {
+	producer := appSetup.OCIProducer
+	consumer := appSetup.OCIConsumer
+	if consumer == nil {
+		return
+	}
+
+	go func() {
+		log := zerolog.Ctx(ctx)
+		for {
+			events, err := consumer.GetEvents(ctx)
+			if err != nil {
+				log.Error().Err(err).Msg("스트림 메시지 읽기 실패")
+				time.Sleep(time.Second)
+				continue
+			}
+			for _, evt := range events {
+				handleQueuedEvent(ctx, appSetup, evt)
+			}
+		}
+	}()
+	_ = producer
+}
+
+func handleQueuedEvent(ctx context.Context, appSetup *setup.AppSetup, evt oci.QueuedEvent) {
+	switch evt.Type {
+	case oci.MatrixMessageEvent:
+		for _, client := range appSetup.MatrixClients {
+			if evt.MatrixEvent != nil {
+				mh := matrix.NewMatrixHandler(
+					matrix.NewMautrixClientAdapter(client),
+					appSetup.ChatwootAPIs,
+					appSetup.DefaultAccountID,
+					appSetup.DB,
+					matrix.NewMessageHelper(client, func(id chatwootapi.AccountID) *chatwootapi.Client { return appSetup.ChatwootAPIs[id] }, false, appSetup.DB),
+					conversation.NewManager(matrix.NewMautrixClientAdapter(client), appSetup.DB, func(id chatwootapi.AccountID) *chatwootapi.Client { return appSetup.ChatwootAPIs[id] }, appSetup.DefaultAccountID, 100),
+				)
+				mh.HandleMessage(ctx, evt.MatrixEvent)
+			}
+		}
+	case oci.MatrixReactionEvent:
+		if evt.MatrixEvent != nil {
+			// 단일 클라이언트만 사용
+			client := appSetup.Client
+			mh := matrix.NewMatrixHandler(
+				matrix.NewMautrixClientAdapter(client),
+				appSetup.ChatwootAPIs,
+				appSetup.DefaultAccountID,
+				appSetup.DB,
+				matrix.NewMessageHelper(client, func(id chatwootapi.AccountID) *chatwootapi.Client { return appSetup.ChatwootAPIs[id] }, false, appSetup.DB),
+				conversation.NewManager(matrix.NewMautrixClientAdapter(client), appSetup.DB, func(id chatwootapi.AccountID) *chatwootapi.Client { return appSetup.ChatwootAPIs[id] }, appSetup.DefaultAccountID, 100),
+			)
+			mh.HandleReaction(ctx, evt.MatrixEvent)
+		}
+	case oci.MatrixRedactionEvent:
+		if evt.MatrixEvent != nil {
+			client := appSetup.Client
+			mh := matrix.NewMatrixHandler(
+				matrix.NewMautrixClientAdapter(client),
+				appSetup.ChatwootAPIs,
+				appSetup.DefaultAccountID,
+				appSetup.DB,
+				matrix.NewMessageHelper(client, func(id chatwootapi.AccountID) *chatwootapi.Client { return appSetup.ChatwootAPIs[id] }, false, appSetup.DB),
+				conversation.NewManager(matrix.NewMautrixClientAdapter(client), appSetup.DB, func(id chatwootapi.AccountID) *chatwootapi.Client { return appSetup.ChatwootAPIs[id] }, appSetup.DefaultAccountID, 100),
+			)
+			mh.HandleRedaction(ctx, evt.MatrixEvent)
+		}
+	case oci.ChatwootMessageEvent:
+		if evt.ChatwootEvent != nil {
+			mh := chatwoot.NewMessageHandler(
+				func(acc chatwootapi.AccountID, inbox chatwootapi.InboxID) *mautrix.Client {
+					client, _ := appSetup.MatrixClientForChatwootAccount(ctx, acc, inbox)
+					return client
+				},
+				appSetup.DB,
+				appSetup.ChatwootAPIs,
+				func(acc chatwootapi.AccountID) *chatwootapi.Client {
+					return setup.GetChatwootAPIForAccount(appSetup.ChatwootAPIs, acc, appSetup.DefaultAccountID)
+				},
+				NewRoomSendLocks(),
+			)
+			_ = mh.HandleMessageCreated(ctx, *evt.ChatwootEvent)
+		}
+	}
+}

--- a/cmd/bot/handlers.go
+++ b/cmd/bot/handlers.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Nocha12/chatwoot-mirroring-bot/internal/conversation"
 	"github.com/Nocha12/chatwoot-mirroring-bot/internal/matrix"
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/oci"
 	"github.com/Nocha12/chatwoot-mirroring-bot/internal/setup"
 	"github.com/Nocha12/chatwoot-mirroring-bot/pkg/chatwootapi"
 	"github.com/rs/zerolog"
@@ -43,31 +44,43 @@ func SetupMatrixHandlers(ctx context.Context, appSetup *setup.AppSetup, roomSend
 		syncer := client.Syncer.(*mautrix.DefaultSyncer)
 
 		// 이벤트 핸들러 등록
-		registerEventHandlers(ctx, syncer, matrixHandler, client)
+		registerEventHandlers(ctx, syncer, matrixHandler, client, appSetup.OCIProducer)
 	}
 }
 
 // registerEventHandlers는 Matrix 이벤트 핸들러를 등록합니다.
-func registerEventHandlers(ctx context.Context, syncer *mautrix.DefaultSyncer, matrixHandler *matrix.MatrixHandler, client *mautrix.Client) {
+func registerEventHandlers(ctx context.Context, syncer *mautrix.DefaultSyncer, matrixHandler *matrix.MatrixHandler, client *mautrix.Client, producer *oci.Producer) {
 	// 메시지 이벤트 핸들러
 	syncer.OnEventType(event.EventMessage, func(ctx context.Context, evt *event.Event) {
 		log := zerolog.Ctx(ctx).With().Str("component", "matrix_message_handler").Logger()
 		ctx = log.WithContext(ctx)
-		matrixHandler.HandleMessage(ctx, evt)
+		if producer != nil {
+			_ = producer.Publish(ctx, oci.QueuedEvent{Type: oci.MatrixMessageEvent, MatrixEvent: evt})
+		} else {
+			matrixHandler.HandleMessage(ctx, evt)
+		}
 	})
 
 	// 리액션 이벤트 핸들러
 	syncer.OnEventType(event.EventReaction, func(ctx context.Context, evt *event.Event) {
 		log := zerolog.Ctx(ctx).With().Str("component", "matrix_reaction_handler").Logger()
 		ctx = log.WithContext(ctx)
-		matrixHandler.HandleReaction(ctx, evt)
+		if producer != nil {
+			_ = producer.Publish(ctx, oci.QueuedEvent{Type: oci.MatrixReactionEvent, MatrixEvent: evt})
+		} else {
+			matrixHandler.HandleReaction(ctx, evt)
+		}
 	})
 
 	// 삭제 이벤트 핸들러
 	syncer.OnEventType(event.EventRedaction, func(ctx context.Context, evt *event.Event) {
 		log := zerolog.Ctx(ctx).With().Str("component", "matrix_redaction_handler").Logger()
 		ctx = log.WithContext(ctx)
-		matrixHandler.HandleRedaction(ctx, evt)
+		if producer != nil {
+			_ = producer.Publish(ctx, oci.QueuedEvent{Type: oci.MatrixRedactionEvent, MatrixEvent: evt})
+		} else {
+			matrixHandler.HandleRedaction(ctx, evt)
+		}
 	})
 
 	// 초대 수락 핸들러

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -47,6 +47,9 @@ func main() {
 	// Matrix 이벤트 핸들러 등록
 	SetupMatrixHandlers(ctx, appSetup, roomSendlocks)
 
+	// 스트림 소비 루프 시작
+	StartConsumerLoop(ctx, appSetup)
+
 	// 백필 작업 시작
 	StartBackfillProcess(ctx, appSetup)
 

--- a/cmd/bot/server.go
+++ b/cmd/bot/server.go
@@ -39,7 +39,7 @@ func StartWebhookServer(ctx context.Context, appSetup *setup.AppSetup, roomSendl
 		},
 		roomSendlocks,
 	)
-	webhookHandler := chatwoot.NewWebhookHandler(messageHandler)
+	webhookHandler := chatwoot.NewWebhookHandler(messageHandler, appSetup.OCIProducer)
 
 	router := http.NewServeMux()
 	router.HandleFunc("/chatwoot", webhookHandler.HandleWebhook)

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -113,3 +113,9 @@ logging:
       max_size: 100
       max_backups: 10
       compress: true
+
+# ===== OCI Streaming Settings =====
+oci_streaming:
+  endpoint: https://streaming.example.com
+  topic: chatwoot-bot
+  credentials: /path/to/oci/credentials

--- a/internal/chatwoot/webhook.go
+++ b/internal/chatwoot/webhook.go
@@ -8,19 +8,22 @@ import (
 
 	"github.com/rs/zerolog/hlog"
 
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/oci"
 	"github.com/Nocha12/chatwoot-mirroring-bot/pkg/chatwootapi"
 )
 
 // WebhookHandler는 Chatwoot 웹훅 요청을 처리하는 구조체입니다.
 type WebhookHandler struct {
 	// 의존성 주입을 위한 필드들
-	handler *MessageHandler
+	handler  *MessageHandler
+	producer *oci.Producer
 }
 
 // NewWebhookHandler는 새로운 WebhookHandler 인스턴스를 생성합니다.
-func NewWebhookHandler(handler *MessageHandler) *WebhookHandler {
+func NewWebhookHandler(handler *MessageHandler, producer *oci.Producer) *WebhookHandler {
 	return &WebhookHandler{
-		handler: handler,
+		handler:  handler,
+		producer: producer,
 	}
 }
 
@@ -82,14 +85,15 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}
-
-		// Matrix 메시지 생성 처리를 비동기로 실행
-		go func() {
-			err := h.handler.HandleMessageCreated(ctx, mc)
-			if err != nil {
-				logger.Error().Err(err).Msg("메시지 생성 처리 실패")
-			}
-		}()
+		if h.producer != nil {
+			_ = h.producer.Publish(ctx, oci.QueuedEvent{Type: oci.ChatwootMessageEvent, ChatwootEvent: &mc})
+		} else {
+			go func() {
+				if err := h.handler.HandleMessageCreated(ctx, mc); err != nil {
+					logger.Error().Err(err).Msg("메시지 생성 처리 실패")
+				}
+			}()
+		}
 
 	default:
 		logger.Debug().Str("event_type", eventType).Msg("처리되지 않는 이벤트 타입")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -29,6 +29,13 @@ type StartNewChat struct {
 	Token    string `yaml:"token"`
 }
 
+// OCIStreamingConfig는 OCI Streaming 연동을 위한 설정을 정의합니다.
+type OCIStreamingConfig struct {
+	Endpoint    string `yaml:"endpoint"`
+	Topic       string `yaml:"topic"`
+	Credentials string `yaml:"credentials"`
+}
+
 // ChatwootAccountConfig는 단일 Chatwoot 계정에 대한 설정을 정의합니다.
 type ChatwootAccountConfig struct {
 	BaseUrl         string                `yaml:"base_url,omitempty"`
@@ -40,12 +47,12 @@ type ChatwootAccountConfig struct {
 
 // DbConfiguration은 데이터베이스 설정만 포함하는 간소화된 설정 구조체입니다.
 type DbConfiguration struct {
-	Database dbutil.Config `yaml:"database"`
-	MasterEncryptionKeyFile string `yaml:"master_encryption_key_file"`
-	LogLevel  string `yaml:"log_level"`
-	LogJSON   bool   `yaml:"log_json"`
-	LogTime   bool   `yaml:"log_time"`
-	LogCaller bool   `yaml:"log_caller"`
+	Database                dbutil.Config `yaml:"database"`
+	MasterEncryptionKeyFile string        `yaml:"master_encryption_key_file"`
+	LogLevel                string        `yaml:"log_level"`
+	LogJSON                 bool          `yaml:"log_json"`
+	LogTime                 bool          `yaml:"log_time"`
+	LogCaller               bool          `yaml:"log_caller"`
 }
 
 // RuntimeConfig는 DB에서 불러온 설정과 실행시간에 필요한 추가 설정을 가지는 구조체입니다.
@@ -56,15 +63,15 @@ type RuntimeConfig struct {
 	AccessToken string
 	DeviceID    string
 
-	ChatwootBaseUrl string
+	ChatwootBaseUrl  string
 	ChatwootAccounts map[chatwootapi.AccountID]*RuntimeChatwootConfig
 
-	MaxMediaWidth       int
-	MaxMediaHeight      int
-	MaxMediaPixels      int
-	MaxMediaSize        int
-	MediaQuality        int
-	MediaConvertWEBP    bool
+	MaxMediaWidth    int
+	MaxMediaHeight   int
+	MaxMediaPixels   int
+	MaxMediaSize     int
+	MediaQuality     int
+	MediaConvertWEBP bool
 
 	Backfill            BackfillConfiguration
 	HomeserverWhitelist HomeserverWhitelist
@@ -87,11 +94,11 @@ type Configuration struct {
 	Username     id.UserID `yaml:"username"`
 	PasswordFile string    `yaml:"password_file"`
 
-	ChatwootBaseUrl string `yaml:"chatwoot_base_url"`
-	ChatwootAccessTokenFile string                `yaml:"chatwoot_access_token_file,omitempty"`
-	ChatwootAccountID       chatwootapi.AccountID `yaml:"chatwoot_account_id,omitempty"`
-	ChatwootInboxID         chatwootapi.InboxID   `yaml:"chatwoot_inbox_id,omitempty"`
-	ChatwootAccounts []ChatwootAccountConfig `yaml:"chatwoot_accounts,omitempty"`
+	ChatwootBaseUrl         string                  `yaml:"chatwoot_base_url"`
+	ChatwootAccessTokenFile string                  `yaml:"chatwoot_access_token_file,omitempty"`
+	ChatwootAccountID       chatwootapi.AccountID   `yaml:"chatwoot_account_id,omitempty"`
+	ChatwootInboxID         chatwootapi.InboxID     `yaml:"chatwoot_inbox_id,omitempty"`
+	ChatwootAccounts        []ChatwootAccountConfig `yaml:"chatwoot_accounts,omitempty"`
 
 	MasterEncryptionKeyFile string `yaml:"master_encryption_key_file"`
 
@@ -110,8 +117,10 @@ type Configuration struct {
 	LogCaller bool   `yaml:"log_caller"`
 
 	HomeserverWhitelist HomeserverWhitelist `yaml:"homeserver_whitelist"`
-	HTTPListenPort int `yaml:"http_listen_port"`
-	StartNewChat StartNewChat `yaml:"start_new_chat"`
+	HTTPListenPort      int                 `yaml:"http_listen_port"`
+	StartNewChat        StartNewChat        `yaml:"start_new_chat"`
+
+	OCIStreaming OCIStreamingConfig `yaml:"oci_streaming"`
 
 	Database dbutil.Config `yaml:"database"`
 }

--- a/internal/oci/streaming.go
+++ b/internal/oci/streaming.go
@@ -1,0 +1,116 @@
+package oci
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/Nocha12/chatwoot-mirroring-bot/pkg/chatwootapi"
+	"maunium.net/go/mautrix/event"
+)
+
+// QueuedEventType 은 스트림에 저장되는 이벤트 종류를 정의합니다.
+type QueuedEventType string
+
+const (
+	// Matrix 측 이벤트
+	MatrixMessageEvent   QueuedEventType = "matrix_message"
+	MatrixReactionEvent  QueuedEventType = "matrix_reaction"
+	MatrixRedactionEvent QueuedEventType = "matrix_redaction"
+	// Chatwoot 측 이벤트
+	ChatwootMessageEvent QueuedEventType = "chatwoot_message"
+)
+
+// QueuedEvent 은 스트림에 저장되는 메시지 구조체입니다.
+type QueuedEvent struct {
+	Type          QueuedEventType             `json:"type"`
+	MatrixEvent   *event.Event                `json:"matrix_event,omitempty"`
+	ChatwootEvent *chatwootapi.MessageCreated `json:"chatwoot_event,omitempty"`
+}
+
+// Producer 는 OCI Streaming 에 메시지를 게시합니다.
+type Producer struct {
+	endpoint string
+	topic    string
+	token    string
+	client   *http.Client
+}
+
+// NewProducer 는 새로운 Producer 를 생성합니다.
+func NewProducer(endpoint, topic, token string) *Producer {
+	return &Producer{endpoint: endpoint, topic: topic, token: token, client: &http.Client{}}
+}
+
+// Publish 는 이벤트를 스트림에 전송합니다.
+func (p *Producer) Publish(ctx context.Context, evt QueuedEvent) error {
+	data, err := json.Marshal(evt)
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("%s/streams/%s/messages", p.endpoint, p.topic)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if p.token != "" {
+		req.Header.Set("Authorization", p.token)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("publish failed: %s", string(body))
+	}
+	return nil
+}
+
+// Consumer 는 OCI Streaming 에서 메시지를 읽어옵니다.
+type Consumer struct {
+	endpoint string
+	topic    string
+	token    string
+	client   *http.Client
+	cursor   string
+}
+
+// NewConsumer 는 새로운 Consumer 를 생성합니다.
+func NewConsumer(endpoint, topic, token string) *Consumer {
+	return &Consumer{endpoint: endpoint, topic: topic, token: token, client: &http.Client{}}
+}
+
+// GetEvents 는 스트림에서 메시지를 읽어 이벤트 배열로 반환합니다.
+func (c *Consumer) GetEvents(ctx context.Context) ([]QueuedEvent, error) {
+	url := fmt.Sprintf("%s/streams/%s/messages?cursor=%s", c.endpoint, c.topic, c.cursor)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", c.token)
+	}
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("consume failed: %s", string(body))
+	}
+	var result struct {
+		Next   string        `json:"next"`
+		Events []QueuedEvent `json:"events"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, err
+	}
+	c.cursor = result.Next
+	return result.Events, nil
+}

--- a/internal/setup/callbacks_and_shutdown.go
+++ b/internal/setup/callbacks_and_shutdown.go
@@ -143,7 +143,7 @@ var (
 )
 
 // loadAuthorizedUsers는 환경 변수에서 허용된 사용자 목록을 읽어옵니다.
-func loadAuthorizedUsers(log zerolog.Logger) {
+func loadAuthorizedUsers(log *zerolog.Logger) {
 	authorizedUsers = make(map[id.UserID]struct{})
 	if list := os.Getenv("AUTHORIZED_MATRIX_USERS"); list != "" {
 		for _, u := range strings.Split(list, ",") {

--- a/internal/setup/oci_setup.go
+++ b/internal/setup/oci_setup.go
@@ -1,0 +1,20 @@
+package setup
+
+import (
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/config"
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/oci"
+)
+
+// SetupOCIStreaming 는 설정을 읽어 OCI Streaming 프로듀서와 컨슈머를 초기화합니다.
+func SetupOCIStreaming(cfg *config.Configuration) (*oci.Producer, *oci.Consumer) {
+	if cfg == nil {
+		return nil, nil
+	}
+	ociCfg := cfg.OCIStreaming
+	if ociCfg.Endpoint == "" || ociCfg.Topic == "" {
+		return nil, nil
+	}
+	producer := oci.NewProducer(ociCfg.Endpoint, ociCfg.Topic, ociCfg.Credentials)
+	consumer := oci.NewConsumer(ociCfg.Endpoint, ociCfg.Topic, ociCfg.Credentials)
+	return producer, consumer
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Nocha12/chatwoot-mirroring-bot/internal/config"
 	"github.com/Nocha12/chatwoot-mirroring-bot/internal/database"
 	"github.com/Nocha12/chatwoot-mirroring-bot/internal/database/queries"
+	"github.com/Nocha12/chatwoot-mirroring-bot/internal/oci"
 	"github.com/Nocha12/chatwoot-mirroring-bot/pkg/chatwootapi"
 	"github.com/rs/zerolog"
 	"maunium.net/go/mautrix"
@@ -30,6 +31,9 @@ type AppSetup struct {
 	AccountMappings  *config.AccountMappingManager
 	ChatwootConfigs  map[int]*config.RuntimeChatwootConfig // ID로 접근하기 위한 Chatwoot 설정 참조
 	MatrixIdentities map[int]*config.MatrixIdentityConfig  // ID로 접근하기 위한 Matrix 아이덴티티 참조
+
+	OCIProducer *oci.Producer
+	OCIConsumer *oci.Consumer
 }
 
 // SetupApp은 설정 파일(configPath) 유무에 따라 적절히 로딩 후
@@ -125,6 +129,9 @@ func SetupApp(configPath string) (*AppSetup, error) {
 		return nil, fmt.Errorf("matrix 아이덴티티 정보 로드 실패: %w", err)
 	}
 
+	// 8.5) OCI Streaming 초기화
+	producer, consumer := SetupOCIStreaming(cfg)
+
 	// 8) Chatwoot 설정 정보를 ID로 접근할 수 있는 맵으로 변환
 	chatwootConfigs := make(map[int]*config.RuntimeChatwootConfig)
 	if cfg == nil {
@@ -183,6 +190,8 @@ func SetupApp(configPath string) (*AppSetup, error) {
 		AccountMappings:  accountMappings,
 		ChatwootConfigs:  chatwootConfigs,
 		MatrixIdentities: matrixIdentities,
+		OCIProducer:      producer,
+		OCIConsumer:      consumer,
 	}
 	if cfg != nil {
 		app.Config = cfg


### PR DESCRIPTION
## Summary
- add OCI streaming producer/consumer package
- integrate OCI streaming config
- enqueue matrix/chatwoot events instead of handling directly when producer is set
- start consumer loop on app start

## Testing
- `CGO_ENABLED=0 go build -tags goolm -o chatwoot ./cmd/bot`
- `golangci-lint run --build-tags goolm ./...`
