### PR TITLE
Update go-build pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
     hooks:
       - id: go-build
         name: go build
-        entry: go build -o chatwoot ./cmd/bot
+        entry: go build -tags goolm -o chatwoot ./cmd/bot
         language: system
       - id: golangci-lint
         name: golangci-lint


### PR DESCRIPTION
## Summary
- update go-build hook entry to compile using goolm

## Testing
- `pre-commit run --files .pre-commit-config.yaml` *(fails: pre-commit not found)*