### PR TITLE
Fix lint command in debug workflow

### DIFF
--- a/.windsurf/workflows/debug-build-error.md
+++ b/.windsurf/workflows/debug-build-error.md
@@ -1,8 +1,9 @@
 ---
-description: go build -o chatwoot ./cmd/bot 를 통한 에러 해결 플로우
+description: go build -tags goolm -o chatwoot ./cmd/bot 를 통한 에러 해결 플로우
 ---
 
-1. go build -o chatwoot ./cmd/bot 실행
-2. 사이드 이펙트를 고려하기 위한 관련된 최대한 많은 파일 탐색
-3. 나오는 버그 수정
-4. 모든 빌드 에러 해결까지 반복
+1. go build -tags goolm -o chatwoot ./cmd/bot 실행
+2. golangci-lint run ./... 실행
+3. 사이드 이펙트를 고려하기 위한 관련된 최대한 많은 파일 탐색
+4. 나오는 버그 수정
+5. 모든 빌드 에러 해결까지 반복


### PR DESCRIPTION
## Summary
- document using `golangci-lint run ./...` in debug workflow

## Testing
- `golangci-lint run ./...` *(fails: could not load export data for `mautrix/crypto/libolm`)*